### PR TITLE
fixed guessDelim corner case

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1252,7 +1252,7 @@ License: MIT
 
 		function guessDelimiter(input, newline, skipEmptyLines, comments, delimitersToGuess)
 		{
-			var bestDelim, bestDelta, fieldCountPrevRow;
+			var bestDelim, bestDelta, fieldCountPrevRow, maxFieldCount;
 
 			delimitersToGuess = delimitersToGuess || [',', '\t', '|', ';', Papa.RECORD_SEP, Papa.UNIT_SEP];
 
@@ -1281,10 +1281,10 @@ License: MIT
 
 					if (typeof fieldCountPrevRow === 'undefined')
 					{
-						fieldCountPrevRow = 0;
+						fieldCountPrevRow = fieldCount;
 						continue;
 					}
-					else if (fieldCount > 1)
+					else if (fieldCount > 0)
 					{
 						delta += Math.abs(fieldCount - fieldCountPrevRow);
 						fieldCountPrevRow = fieldCount;
@@ -1294,11 +1294,13 @@ License: MIT
 				if (preview.data.length > 0)
 					avgFieldCount /= (preview.data.length - emptyLinesCount);
 
-				if ((typeof bestDelta === 'undefined' || delta > bestDelta)
+				if ((typeof bestDelta === 'undefined' || delta <= bestDelta)
+					&& (typeof maxFieldCount === 'undefined' || avgFieldCount > maxFieldCount)
 					&& avgFieldCount > 1.99)
 				{
 					bestDelta = delta;
 					bestDelim = delim;
+					maxFieldCount = avgFieldCount;
 				}
 			}
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1204,6 +1204,30 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Pipe delimiter is guessed correctly when high delta in commas",
+		notes: "Lower delta should be better",
+		input: 'one|two|three|four|five\none|two,two,two,two|three|four|five\none|two,two,two|three|four|five',
+		config: {},
+		expected: {
+			data: [
+				['one','two','three','four','five'],
+				['one','two,two,two,two','three','four','five'],
+				['one','two,two,two','three','four','five']
+			],
+			errors: []
+		}
+	},
+	{
+		description: "Correct delimiter is guessed when deltas are equal, but one produces more",
+		notes: "When deltas are equal, the higher number of fields should be chosen",
+		config: {},
+		input: 'a,b,c\na,b,c|d|e|f',
+		expected: {
+			data: [['a', 'b', 'c'], ['a','b','c|d|e|f']],
+			errors: []
+		}
+	},
+	{
 		description: "Single quote as quote character",
 		notes: "Must parse correctly when single quote is specified as a quote character",
 		input: "a,b,'c,d'",


### PR DESCRIPTION
See CRIBL-14950 for details. Failed to guess the correct delimiter in some corner cases where delim is `|`, but `,`s are used frequently inside fields in varying numbers row-to-row