### PR TITLE
Fixed CSV parsing issue when first cell is empty

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1234,7 +1234,7 @@ License: MIT
 			}
 
 			var incrementBy = 1;
-			if (!_results.data[0] || Array.isArray(_results.data[0]))
+			if (!_results.data.length || Array.isArray(_results.data[0]))
 			{
 				_results.data = _results.data.map(processRow);
 				incrementBy = _results.data.length;

--- a/tests/node-tests.js
+++ b/tests/node-tests.js
@@ -161,6 +161,20 @@ describe('PapaParse', function() {
 		});
 	});
 
+	it('piped streaming CSV should be correctly parsed when header is true', function(done) {
+		var data = [];
+		var readStream = fs.createReadStream(__dirname + '/sample-header.csv', 'utf8');
+		var csvStream = readStream.pipe(Papa.parse(Papa.NODE_STREAM_INPUT, {header: true}));
+		csvStream.on('data', function(item) {
+			data.push(item);
+		});
+		csvStream.on('end', function() {
+			assert.deepEqual(data[0], { title: 'test title 01', name: 'test name 01' });
+			assert.deepEqual(data[1],  { title: '', name: 'test name 02' });
+			done();
+		});
+	});
+
 	it('should support pausing and resuming asynchronously when streaming', function(done) {
 		var rows = [];
 		Papa.parse(fs.createReadStream(__dirname + '/long-sample.csv', 'utf8'), {

--- a/tests/sample-header.csv
+++ b/tests/sample-header.csv
@@ -1,0 +1,3 @@
+title,name
+test title 01,test name 01
+,test name 02


### PR DESCRIPTION
Bug:
CSV parsing issue when first cell is empty, affecting querying of cribl search lookup dataset. See SEARCH-2774 for details. 

Fix:
port over the following change from the original source repo: https://github.com/mholt/PapaParse/pull/707/files